### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that b
 - ⚡ **Easy Setup** – One-click install in [Cursor](https://cursor.sh) or simple manual setup
 - 🔬 **Comprehensive** – Drug info, health stats, medical literature, clinical guidelines, pediatric sources
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jamesanz-medical-mcp).
+
 ## Quick Start
 
 Ready to bring medical intelligence into your AI workflow? Install in seconds:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jamesanz-medical-mcp)