### PR TITLE
Send diagnostic logging to stderr (stdout is reserved for JSON-RPC in stdio mode)

### DIFF
--- a/src/cache/manager.ts
+++ b/src/cache/manager.ts
@@ -214,7 +214,7 @@ class CacheManager {
     }
 
     if (keysToDelete.length > 0) {
-      console.log(
+      console.error(
         `🧹 Cache cleanup: Removed ${keysToDelete.length} expired entries`,
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,7 +509,7 @@ async function runHttp(server: McpServer) {
   });
 
   app.listen(port, host, () => {
-    console.log(`✅ Medical MCP Server (HTTP) on http://${host}:${port}/mcp`);
+    console.error(`✅ Medical MCP Server (HTTP) on http://${host}:${port}/mcp`);
   })
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1511,7 +1511,7 @@ export async function searchGoogleScholar(
 ): Promise<GoogleScholarArticle[]> {
   let browser;
   try {
-    console.log(`🔍 Scraping Google Scholar for: ${query}`);
+    console.error(`🔍 Scraping Google Scholar for: ${query}`);
 
     // Add random delay to avoid rate limiting
     await randomDelay(2000, 5000);
@@ -1804,7 +1804,7 @@ export async function searchGoogleScholar(
 export async function searchMedicalDatabases(
   query: string,
 ): Promise<GoogleScholarArticle[]> {
-  console.log(`🔍 Searching medical databases for: ${query}`);
+  console.error(`🔍 Searching medical databases for: ${query}`);
 
   // Try multiple medical databases in parallel
   const searches = await Promise.allSettled([
@@ -1858,7 +1858,7 @@ async function searchCochraneLibrary(
 ): Promise<GoogleScholarArticle[]> {
   let browser;
   try {
-    console.log(`🔍 Scraping Cochrane Library for: ${query}`);
+    console.error(`🔍 Scraping Cochrane Library for: ${query}`);
 
     await randomDelay(1000, 3000);
 
@@ -1937,7 +1937,7 @@ async function searchClinicalTrials(
   query: string,
 ): Promise<GoogleScholarArticle[]> {
   try {
-    console.log(`🔍 Searching ClinicalTrials.gov for: ${query}`);
+    console.error(`🔍 Searching ClinicalTrials.gov for: ${query}`);
 
     const response = await superagent
       .get("https://clinicaltrials.gov/api/v2/studies")
@@ -1987,7 +1987,7 @@ async function searchClinicalTrials(
 export async function searchMedicalJournals(
   query: string,
 ): Promise<GoogleScholarArticle[]> {
-  console.log(`🔍 Searching medical journals for: ${query}`);
+  console.error(`🔍 Searching medical journals for: ${query}`);
 
   const journalSearches = await Promise.allSettled([
     searchJournal("NEJM", query),
@@ -2059,7 +2059,7 @@ async function fetchFullTextFromPMC(pmc_id: string): Promise<string | null> {
       }
     } catch (xmlError) {
       // Continue to next method
-      console.log(`PMC XML method failed for ${pmc_id}, trying HTML method`);
+      console.error(`PMC XML method failed for ${pmc_id}, trying HTML method`);
     }
 
     // Method 2: Scrape HTML page using puppeteer
@@ -2729,7 +2729,7 @@ export async function searchBrightFuturesGuidelines(
 ): Promise<PediatricGuideline[]> {
   let browser;
   try {
-    console.log(`🔍 Scraping Bright Futures for: ${query}`);
+    console.error(`🔍 Scraping Bright Futures for: ${query}`);
 
     await randomDelay(1000, 3000);
 
@@ -2803,7 +2803,7 @@ export async function searchAAPPolicyStatements(
 ): Promise<PediatricGuideline[]> {
   let browser;
   try {
-    console.log(`🔍 Scraping AAP Policy Statements for: ${query}`);
+    console.error(`🔍 Scraping AAP Policy Statements for: ${query}`);
 
     await randomDelay(1000, 3000);
 

--- a/src/utils/deduplication.ts
+++ b/src/utils/deduplication.ts
@@ -377,7 +377,7 @@ export function deduplicatePapers(papers: PaperLike[]): DeduplicationResult {
     if (!isDuplicate) {
       unique.push(paper);
     } else if (logRemoved) {
-      console.log(
+      console.error(
         `[DEDUP] Removed duplicate: "${paper.title}" - ${duplicateReason}`,
       );
     }


### PR DESCRIPTION
## Problem

On the stdio transport (the default for Claude Desktop and most MCP clients), `stdout` is reserved exclusively for JSON-RPC messages. Several `console.log(...)` calls write human-readable text to `stdout`, corrupting the protocol stream. The client then fails to parse the next frame and surfaces errors such as:

```
Unexpected token '✅', "✅ Medical "... is not valid JSON
```

The stdio startup banner was already removed from `main`, but 11 `console.log` calls remain and fire on common paths. The scraper/progress logs in `utils.ts` (`search-google-scholar`, `search-medical-journals`, `search-medical-databases`, Cochrane, ClinicalTrials.gov, Bright Futures, AAP) re-trigger the error on every such call in stdio mode.

## Fix

Route diagnostic logging to `stderr` (`console.log` -> `console.error`) in:

- `src/index.ts` (HTTP-mode banner)
- `src/utils.ts` (8 scraper/progress logs)
- `src/cache/manager.ts`
- `src/utils/deduplication.ts`

`console.error` writes to `stderr`, which clients ignore for protocol purposes but still capture in logs, so no diagnostic value is lost. No behavior change beyond the output stream. `build/` is gitignored, so this is source-only.

## Note

This enforces the MCP stdio rule: a server must write nothing but valid JSON-RPC to `stdout`. A blanket guard (`console.log = console.error`) at the entry point is an alternative belt-and-suspenders approach, but converting the calls keeps intent explicit.
